### PR TITLE
chore: use official nodemailer types

### DIFF
--- a/src/types/nodemailer.d.ts
+++ b/src/types/nodemailer.d.ts
@@ -1,1 +1,0 @@
-declare module 'nodemailer';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["@types/node", "@types/react", "@types/react-dom"],
+    "types": ["@types/node", "@types/react", "@types/react-dom", "nodemailer"],
     "baseUrl": ".",
     "paths": { "@/*": ["src/*"] }
   },


### PR DESCRIPTION
## Summary
- remove hand-rolled nodemailer module declaration
- configure TypeScript to include Nodemailer types

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68bce703c10c8327a6b1c0e947218b10